### PR TITLE
Fixed polish locale, removed buggy random tests

### DIFF
--- a/locale/pl.js
+++ b/locale/pl.js
@@ -25,10 +25,8 @@ var lessThanHundred = (function () {
      6: P('sześć').mutates('before', 'naście', 'szes'),
      7: 'siedem',
      8: 'osiem',
-     9: P('dziewięć').mutates('before', 'dziesiąt', 'dziewiec')
-      .mutates('before', 'set', 'dziewięc')
-      .mutates('before', 'naście', 'dziewięt'),
-    10: 'dziesięc'
+     9: P('dziewięć').mutates('before', 'naście', 'dziewięt'),
+    10: 'dziesięć'
   };
 
   var tenDziesiat = P('dziesiąt').asSuffix()

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   } ],
   "devDependencies": {
     "mocha": "",
-    "jshint": "",
-    "slownie": ""
+    "jshint": ""
   },
   "tonicExampleFilename": "example.js"
 }

--- a/test/locale/pl.js
+++ b/test/locale/pl.js
@@ -6,61 +6,29 @@ var t = require('../util').inWordsTest.bind(null, pl);
 
 describe('pl', function () {
 
-  function testUsingSlownie() {
-    var Slownie = new (require('slownie').Slownie)();
-
-    function test(i) {
-      if (i !== '0') {
-        t(i, Slownie.get(i));
-      }
-    }
-
-    function randomDigit() {
-      return Math.floor(Math.random() * 10);
-    }
-
-    function randomNumber(digits) {
-      var res = '';
-      for (; digits; --digits) {
-        res += randomDigit();
-      }
-      return res;
-    }
-
-    for (var i = 1; i < 28; ++i) {
-      for (var n = 0; n < 100; ++n) {
-        test(randomNumber(i));
-      }
-    }
-  }
-  try {
-    testUsingSlownie();
-  } catch (e) {
-    console.warn('Testing random polish numbers only works with slownie installed');
-  }
-
   t('0', 'zero');
   t('1', 'jeden');
   t('2', 'dwa');
   t('3', 'trzy');
   t('4', 'cztery');
   t('7', 'siedem');
+  t('10', 'dziesięć');
   t('12', 'dwanaście');
   t('17', 'siedemnaście');
   t('26', 'dwadzieścia sześć');
   t('30', 'trzydzieści');
   t('50', 'pięćdziesiąt');
   t('66', 'sześćdziesiąt sześć');
-  t('93', 'dziewiecdziesiąt trzy');
-  t('99', 'dziewiecdziesiąt dziewięć');
+  t('93', 'dziewięćdziesiąt trzy');
+  t('99', 'dziewięćdziesiąt dziewięć');
   t('141', 'sto czterdzieści jeden');
   t('156', 'sto pięćdziesiąt sześć');
   t('166', 'sto sześćdziesiąt sześć');
   t('270', 'dwieście siedemdziesiąt');
   t('346', 'trzysta czterdzieści sześć');
-  t('396', 'trzysta dziewiecdziesiąt sześć');
+  t('396', 'trzysta dziewięćdziesiąt sześć');
   t('501', 'pięćset jeden');
-  t('892', 'osiemset dziewiecdziesiąt dwa');
+  t('892', 'osiemset dziewięćdziesiąt dwa');
   t('1625', 'tysiąc sześćset dwadzieścia pięć');
   t('3135', 'trzy tysiące sto trzydzieści pięć');
   t('4839', 'cztery tysiące osiemset trzydzieści dziewięć');
@@ -69,13 +37,13 @@ describe('pl', function () {
   t('15651', 'piętnaście tysięcy sześćset pięćdziesiąt jeden');
   t('26383', 'dwadzieścia sześć tysięcy trzysta osiemdziesiąt trzy');
   t('55042', 'pięćdziesiąt pięć tysięcy czterdzieści dwa');
-  t('93345', 'dziewiecdziesiąt trzy tysiące trzysta czterdzieści pięć');
+  t('93345', 'dziewięćdziesiąt trzy tysiące trzysta czterdzieści pięć');
   t('127180', 'sto dwadzieścia siedem tysięcy sto osiemdziesiąt');
-  t('197431', 'sto dziewiecdziesiąt siedem tysięcy czterysta trzydzieści ' +
+  t('197431', 'sto dziewięćdziesiąt siedem tysięcy czterysta trzydzieści ' +
     'jeden');
   t('303804', 'trzysta trzy tysiące osiemset cztery');
   t('700003', 'siedemset tysięcy trzy');
-  t('758926', 'siedemset pięćdziesiąt osiem tysięcy dziewięcset dwadzieścia ' +
+  t('758926', 'siedemset pięćdziesiąt osiem tysięcy dziewięćset dwadzieścia ' +
     'sześć');
   t('1288803', 'milion dwieście osiemdziesiąt osiem tysięcy osiemset ' +
     'trzy');
@@ -89,39 +57,39 @@ describe('pl', function () {
     'dwieście trzydzieści cztery');
   t('109158181', 'sto dziewięć milionów sto pięćdziesiąt osiem tysięcy sto ' +
     'osiemdziesiąt jeden');
-  t('409093722', 'czterysta dziewięć milionów dziewiecdziesiąt trzy tysiące ' +
+  t('409093722', 'czterysta dziewięć milionów dziewięćdziesiąt trzy tysiące ' +
     'siedemset dwadzieścia dwa');
   t('1001000000', 'miliard milion');
   t('1644458481', 'miliard sześćset czterdzieści cztery miliony czterysta ' +
     'pięćdziesiąt osiem tysięcy czterysta osiemdziesiąt jeden');
   t('3074793073', 'trzy miliardy siedemdziesiąt cztery miliony siedemset ' +
-    'dziewiecdziesiąt trzy tysiące siedemdziesiąt trzy');
+    'dziewięćdziesiąt trzy tysiące siedemdziesiąt trzy');
   t('12166242023', 'dwanaście miliardów sto sześćdziesiąt sześć milionów ' +
     'dwieście czterdzieści dwa tysiące dwadzieścia trzy');
-  t('27921921047', 'dwadzieścia siedem miliardów dziewięcset dwadzieścia ' +
-    'jeden milionów dziewięcset dwadzieścia jeden tysięcy czterdzieści ' +
+  t('27921921047', 'dwadzieścia siedem miliardów dziewięćset dwadzieścia ' +
+    'jeden milionów dziewięćset dwadzieścia jeden tysięcy czterdzieści ' +
     'siedem');
-  t('179946793412', 'sto siedemdziesiąt dziewięć miliardów dziewięcset ' +
-    'czterdzieści sześć milionów siedemset dziewiecdziesiąt trzy tysiące ' +
+  t('179946793412', 'sto siedemdziesiąt dziewięć miliardów dziewięćset ' +
+    'czterdzieści sześć milionów siedemset dziewięćdziesiąt trzy tysiące ' +
     'czterysta dwanaście');
   t('538072047518', 'pięćset trzydzieści osiem miliardów siedemdziesiąt dwa ' +
     'miliony czterdzieści siedem tysięcy pięćset osiemnaście');
-  t('3098492052366', 'trzy biliony dziewiecdziesiąt osiem miliardów ' +
-    'czterysta dziewiecdziesiąt dwa miliony pięćdziesiąt dwa tysiące trzysta ' +
+  t('3098492052366', 'trzy biliony dziewięćdziesiąt osiem miliardów ' +
+    'czterysta dziewięćdziesiąt dwa miliony pięćdziesiąt dwa tysiące trzysta ' +
     'sześćdziesiąt sześć');
   t('25713771644907', 'dwadzieścia pięć bilionów siedemset trzynaście ' +
     'miliardów siedemset siedemdziesiąt jeden milionów sześćset czterdzieści ' +
-    'cztery tysiące dziewięcset siedem');
+    'cztery tysiące dziewięćset siedem');
   t('87407743736557', 'osiemdziesiąt siedem bilionów czterysta siedem ' +
     'miliardów siedemset czterdzieści trzy miliony siedemset trzydzieści ' +
     'sześć tysięcy pięćset pięćdziesiąt siedem');
-  t('799262083749807', 'siedemset dziewiecdziesiąt dziewięć bilionów ' +
+  t('799262083749807', 'siedemset dziewięćdziesiąt dziewięć bilionów ' +
     'dwieście sześćdziesiąt dwa miliardy osiemdziesiąt trzy miliony ' +
     'siedemset czterdzieści dziewięć tysięcy osiemset siedem');
   t('8754785357174394', 'osiem biliardów siedemset pięćdziesiąt cztery ' +
     'biliony siedemset osiemdziesiąt pięć miliardów trzysta pięćdziesiąt ' +
     'siedem milionów sto siedemdziesiąt cztery tysiące trzysta ' +
-    'dziewiecdziesiąt cztery');
+    'dziewięćdziesiąt cztery');
   t('105840805681074130', 'sto pięć biliardów osiemset czterdzieści bilionów ' +
     'osiemset pięć miliardów sześćset osiemdziesiąt jeden milionów ' +
     'siedemdziesiąt cztery tysiące sto trzydzieści');
@@ -137,26 +105,26 @@ describe('pl', function () {
     'milionów trzysta siedemdziesiąt pięć tysięcy');
   t('1643865203499258700000', 'tryliard sześćset czterdzieści trzy tryliony ' +
     'osiemset sześćdziesiąt pięć biliardów dwieście trzy biliony czterysta ' +
-    'dziewiecdziesiąt dziewięć miliardów dwieście pięćdziesiąt osiem ' +
+    'dziewięćdziesiąt dziewięć miliardów dwieście pięćdziesiąt osiem ' +
     'milionów siedemset tysięcy');
   t('16438652034992587000000', 'szesnaście tryliardów czterysta trzydzieści ' +
     'osiem trylionów sześćset pięćdziesiąt dwa biliardy trzydzieści cztery ' +
-    'biliony dziewięcset dziewiecdziesiąt dwa miliardy pięćset osiemdziesiąt ' +
+    'biliony dziewięćset dziewięćdziesiąt dwa miliardy pięćset osiemdziesiąt ' +
     'siedem milionów');
   t('164386520349925870000000', 'sto sześćdziesiąt cztery tryliardy trzysta ' +
     'osiemdziesiąt sześć trylionów pięćset dwadzieścia biliardów trzysta ' +
-    'czterdzieści dziewięć bilionów dziewięcset dwadzieścia pięć miliardów ' +
+    'czterdzieści dziewięć bilionów dziewięćset dwadzieścia pięć miliardów ' +
     'osiemset siedemdziesiąt milionów');
   t('1643865203499258700000000', 'kwadrylion sześćset czterdzieści trzy ' +
     'tryliardy osiemset sześćdziesiąt pięć trylionów dwieście trzy biliardy ' +
-    'czterysta dziewiecdziesiąt dziewięć bilionów dwieście pięćdziesiąt ' +
+    'czterysta dziewięćdziesiąt dziewięć bilionów dwieście pięćdziesiąt ' +
     'osiem miliardów siedemset milionów');
   t('16438652034992587000000000', 'szesnaście kwadrylionów czterysta ' +
     'trzydzieści osiem tryliardów sześćset pięćdziesiąt dwa tryliony ' +
-    'trzydzieści cztery biliardy dziewięcset dziewiecdziesiąt dwa biliony ' +
+    'trzydzieści cztery biliardy dziewięćset dziewięćdziesiąt dwa biliony ' +
     'pięćset osiemdziesiąt siedem miliardów');
   t('164386520349925870000000000', 'sto sześćdziesiąt cztery kwadryliony ' +
     'trzysta osiemdziesiąt sześć tryliardów pięćset dwadzieścia trylionów ' +
-    'trzysta czterdzieści dziewięć biliardów dziewięcset dwadzieścia pięć ' +
+    'trzysta czterdzieści dziewięć biliardów dziewięćset dwadzieścia pięć ' +
     'bilionów osiemset siedemdziesiąt miliardów');
 });


### PR DESCRIPTION
Correct forms:
[9 - dziewięć](http://sjp.pl/dziewi%C4%99%C4%87)
[90 - dziewięćdziesiąt](http://sjp.pl/dziewi%C4%99%C4%87dziesi%C4%85t)
[900 - dziewięćset](http://sjp.pl/dziewi%C4%99%C4%87set)
[10 - dziesięć](http://sjp.pl/dziesi%C4%99%C4%87)

The lib that was used for random testing has this typo too, so I removed these tests.